### PR TITLE
FPGA: add bi-directional test to board_test

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/board_test.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/board_test.hpp
@@ -361,8 +361,8 @@ size_t ShimMetrics::TestGlobalMem(sycl::queue &q) {
 // *hostbuf_wr, size_t block_bytes, size_t total_bytes)
 // 3. struct Speed ReadSpeed(queue &q, buffer<char,1> &device_buffer, char
 // *hostbuf_rd, size_t block_bytes, size_t total_bytes)
-// 4. struct Speed ReadWriteSpeed(queue &q, buffer<char, 1> &device_buffer1, 
-// buffer<char, 1> &device_buffer2, char *hostbuf_1, char *hostbuf_2, 
+// 4. struct Speed ReadWriteSpeed(queue &q, buffer<char, 1> &device_buffer1,
+// buffer<char, 1> &device_buffer2, char *hostbuf_1, char *hostbuf_2,
 // size_t block_bytes, size_t total_bytes)
 // 5. bool CheckResults
 // 6. unsigned long SyclGetQStExecTimeNs(event e)
@@ -390,10 +390,10 @@ int ShimMetrics::HostSpeed(sycl::queue &q) {
   // Buffer that WriteSpeed and ReadSpeed functions write to & read from
   sycl::buffer<char, 1> device_buffer{sycl::range<1>{kMaxChars}};
   // Two buffers used by the ReadWriteSpeed function
-  sycl::buffer<char, 1> device_buffer_rw1{sycl::range<1>{kMaxChars},
-      {sycl::property::buffer::mem_channel{1}}};
-  sycl::buffer<char, 1> device_buffer_rw2{sycl::range<1>{kMaxChars},
-      {sycl::property::buffer::mem_channel{2}}};
+  sycl::buffer<char, 1> device_buffer_rw1{
+      sycl::range<1>{kMaxChars}, {sycl::property::buffer::mem_channel{1}}};
+  sycl::buffer<char, 1> device_buffer_rw2{
+      sycl::range<1>{kMaxChars}, {sycl::property::buffer::mem_channel{2}}};
 
   // **** Host memory allocation and initialization **** //
 
@@ -486,7 +486,7 @@ int ShimMetrics::HostSpeed(sycl::queue &q) {
 
   // Fastest transfer value used in read-write bandwidth calculation
   float write_topspeed = 0;
- 
+
   std::cout << "\nWriting " << (kMaxBytes / kKB)
             << " KBs with block size (in bytes) below:\n\n";
   std::cout << std::setw(10) << std::right << "Block Size "
@@ -548,7 +548,7 @@ int ShimMetrics::HostSpeed(sycl::queue &q) {
 
   // Fastest transfer value used in read-write bandwidth calculation
   float readwrite_topspeed = 0;
- 
+
   std::cout << "\nReading-writing " << (kMaxBytes / kKB)
             << " KBs with block size (in bytes) below:\n\n";
   std::cout << std::setw(10) << std::right << "Block Size "

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/board_test.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/board_test.hpp
@@ -357,13 +357,16 @@ size_t ShimMetrics::TestGlobalMem(sycl::queue &q) {
 // More details about these funtions can be found with the corresponsing
 // definitions
 // 1. size_t TestGlobalMem(queue &q)
-// 2. struct Speed WriteSpeed(queue &q, buffer<char,1> &device_buffer, char
+// 2. struct Speed WriteSpeed(queue &q, buffer<char,1> &device_buffer1, char
 // *hostbuf_wr, size_t block_bytes, size_t total_bytes)
-// 3. struct Speed ReadSpeed(queue &q, buffer<char,1> &device_buffer, char
+// 3. struct Speed ReadSpeed(queue &q, buffer<char,1> &device_buffer1, char
 // *hostbuf_rd, size_t block_bytes, size_t total_bytes)
-// 4. bool CheckResults
-// 4. unsigned long SyclGetQStExecTimeNs(event e)
-// 5. unsigned long SyclGetTotalTimeNs(event first_evt, event last_evt)
+// 4. struct Speed ReadWriteSpeed(queue &q, buffer<char, 1> &device_buffer1, 
+// buffer<char, 1> &device_buffer2, char *hostbuf_1, char *hostbuf_2, 
+// size_t block_bytes, size_t total_bytes)
+// 5. bool CheckResults
+// 6. unsigned long SyclGetQStExecTimeNs(event e)
+// 7. unsigned long SyclGetTotalTimeNs(event first_evt, event last_evt)
 
 int ShimMetrics::HostSpeed(sycl::queue &q) {
   // Total bytes to transfer
@@ -386,6 +389,11 @@ int ShimMetrics::HostSpeed(sycl::queue &q) {
   // Creating device buffer to span kMaxBytes size
   // Buffer that WriteSpeed and ReadSpeed functions write to & read from
   sycl::buffer<char, 1> device_buffer{sycl::range<1>{kMaxChars}};
+  // Two buffers used by the ReadWriteSpeed function
+  sycl::buffer<char, 1> device_buffer_rw1{sycl::range<1>{kMaxChars},
+      {sycl::property::buffer::mem_channel{1}}};
+  sycl::buffer<char, 1> device_buffer_rw2{sycl::range<1>{kMaxChars},
+      {sycl::property::buffer::mem_channel{2}}};
 
   // **** Host memory allocation and initialization **** //
 
@@ -395,14 +403,22 @@ int ShimMetrics::HostSpeed(sycl::queue &q) {
   char *hostbuf_rd = new char[kMaxBytes];
   char *hostbuf_wr = new char[kMaxBytes];
 
+  // hostbuf_rw1 is used by ReadWriteSpeed function to get input data to device
+  // buffer and hostbuf_rw2 is used to store data read from device buffer
+  char *hostbuf_rw1 = new char[kMaxBytes];
+  char *hostbuf_rw2 = new char[kMaxBytes];
+
   // Initializing input on host to be written to device buffer
   srand(kRandomSeed);
   // Create sequence: 0 rand1 ~2 rand2 4 ...
   for (size_t j = 0; j < kMaxChars; j++) {
-    if (j % 2 == 0)
+    if (j % 2 == 0) {
       hostbuf_wr[j] = (j & 2) ? ~j : j;
-    else
+      hostbuf_rw1[j] = (j & 2) ? ~j : j;
+    } else {
       hostbuf_wr[j] = rand() * rand();
+      hostbuf_rw1[j] = rand() * rand();
+    }
   }
 
   // *** Warm-up link before measuring bandwidth *** //
@@ -411,6 +427,12 @@ int ShimMetrics::HostSpeed(sycl::queue &q) {
   WriteSpeed(q, device_buffer, hostbuf_wr, block_bytes, kMaxBytes);
   // Reading from device buffer into allocated host memory
   ReadSpeed(q, device_buffer, hostbuf_rd, block_bytes, kMaxBytes);
+  // Reading and writing between device buffer and allocated host memory
+  // Initial run writes to device_buffer2 so when we read from it later, we can
+  // verify the results. The data read on this first run (from device_buffer1)
+  // will contain garbage data.
+  ReadWriteSpeed(q, device_buffer_rw2, device_buffer_rw1, hostbuf_rw1,
+                 hostbuf_rw2, block_bytes, kMaxBytes);
 
   // **** Block transfers to measure bandwidth **** //
 
@@ -424,6 +446,7 @@ int ShimMetrics::HostSpeed(sycl::queue &q) {
   // values from each iteration are analyzed to report bandwidth
   struct Speed rd_bw[iterations];
   struct Speed wr_bw[iterations];
+  struct Speed rw_bw[iterations];
 
   // std::cout is manipulated to format output
   // Storing old state of std::cout to restore
@@ -441,8 +464,11 @@ int ShimMetrics::HostSpeed(sycl::queue &q) {
               << " KB blocks ...\n";
     wr_bw[i] = WriteSpeed(q, device_buffer, hostbuf_wr, block_bytes, kMaxBytes);
     rd_bw[i] = ReadSpeed(q, device_buffer, hostbuf_rd, block_bytes, kMaxBytes);
+    rw_bw[i] = ReadWriteSpeed(q, device_buffer_rw1, device_buffer_rw2,
+                              hostbuf_rw1, hostbuf_rw2, block_bytes, kMaxBytes);
     // Verify value read back matches value that was written to device
     result &= CheckResults(hostbuf_wr, hostbuf_rd, kMaxChars);
+    result &= CheckResults(hostbuf_rw1, hostbuf_rw2, kMaxChars);
     // Restoring old format after each CheckResults function call to print
     // correct format in current loop
     std::cout.copyfmt(old_state);
@@ -460,15 +486,23 @@ int ShimMetrics::HostSpeed(sycl::queue &q) {
 
   // Fastest transfer value used in read-write bandwidth calculation
   float write_topspeed = 0;
-
+ 
   std::cout << "\nWriting " << (kMaxBytes / kKB)
-            << " KBs with block size (in bytes) below:\n";
-  std::cout << "\nBlock_Size Avg Max Min End-End (MB/s)\n";
+            << " KBs with block size (in bytes) below:\n\n";
+  std::cout << std::setw(10) << std::right << "Block Size "
+            << std::setw(10) << std::right << "Avg"
+            << std::setw(10) << std::right << "Max"
+            << std::setw(10) << std::right << "Min"
+            << std::setw(10) << std::right << "End-End"
+            << std::setw(10) << std::right << "(MB/s)\n";
 
   for (size_t i = 0; i < iterations; i++, block_bytes *= 2) {
-    std::cout << std::setw(8) << block_bytes << " " << std::setprecision(2)
-              << std::fixed << wr_bw[i].average << " " << wr_bw[i].fastest
-              << " " << wr_bw[i].slowest << " " << wr_bw[i].total << " \n";
+    std::cout << std::setw(10) << block_bytes << " "
+              << std::fixed << std::setprecision(2)
+              << std::setw(10) << wr_bw[i].average
+              << std::setw(10) << wr_bw[i].fastest
+              << std::setw(10) << wr_bw[i].slowest
+              << std::setw(10) << wr_bw[i].total << "\n";
     if (wr_bw[i].fastest > write_topspeed) write_topspeed = wr_bw[i].fastest;
     if (wr_bw[i].total > write_topspeed) write_topspeed = wr_bw[i].total;
     // Restoring old format after each CheckResults function call to print
@@ -485,15 +519,56 @@ int ShimMetrics::HostSpeed(sycl::queue &q) {
   float read_topspeed = 0;
 
   std::cout << "\nReading " << (kMaxBytes / kKB)
-            << " KBs with block size (in bytes) below:\n";
-  std::cout << "\nBlock_Size Avg Max Min End-End (MB/s)\n";
+            << " KBs with block size (in bytes) below:\n\n";
+  std::cout << std::setw(10) << std::right << "Block Size "
+            << std::setw(10) << std::right << "Avg"
+            << std::setw(10) << std::right << "Max"
+            << std::setw(10) << std::right << "Min"
+            << std::setw(10) << std::right << "End-End"
+            << std::setw(10) << std::right << "(MB/s)\n";
 
   for (size_t i = 0; i < iterations; i++, block_bytes *= 2) {
-    std::cout << std::setw(8) << block_bytes << " " << std::setprecision(2)
-              << std::fixed << rd_bw[i].average << " " << rd_bw[i].fastest
-              << " " << rd_bw[i].slowest << " " << rd_bw[i].total << " \n";
+    std::cout << std::setw(10) << block_bytes << " "
+              << std::fixed << std::setprecision(2)
+              << std::setw(10) << rd_bw[i].average
+              << std::setw(10) << rd_bw[i].fastest
+              << std::setw(10) << rd_bw[i].slowest
+              << std::setw(10) << rd_bw[i].total << "\n";
     if (rd_bw[i].fastest > read_topspeed) read_topspeed = rd_bw[i].fastest;
     if (rd_bw[i].total > read_topspeed) read_topspeed = rd_bw[i].total;
+    // Restoring old format after each CheckResults function call to print
+    // correct format in current loop
+    std::cout.copyfmt(old_state);
+  }
+
+  // **** Report results from readwrites to/from device **** //
+
+  // Restoring value of block_bytes as it changed in for loop above
+  block_bytes = kMinBytes;
+
+  // Fastest transfer value used in read-write bandwidth calculation
+  float readwrite_topspeed = 0;
+ 
+  std::cout << "\nReading-writing " << (kMaxBytes / kKB)
+            << " KBs with block size (in bytes) below:\n\n";
+  std::cout << std::setw(10) << std::right << "Block Size "
+            // << std::setw(10) << std::right << "Avg"
+            // << std::setw(10) << std::right << "Max"
+            // << std::setw(10) << std::right << "Min"
+            << std::setw(10) << std::right << "End-End"
+            << std::setw(10) << std::right << "(MB/s)\n";
+
+  for (size_t i = 0; i < iterations; i++, block_bytes *= 2) {
+    std::cout << std::setw(10) << block_bytes << " "
+              << std::fixed << std::setprecision(2)
+              // << std::setw(10) << "n/a"
+              // << std::setw(10) << "n/a"
+              // << std::setw(10) << "n/a"
+              << std::setw(10) << rw_bw[i].total << "\n";
+    // if (rw_bw[i].fastest > readwrite_topspeed) readwrite_topspeed = rw_bw[i].fastest;
+    if (rw_bw[i].total > readwrite_topspeed) {
+      readwrite_topspeed = rw_bw[i].total;
+    }
     // Restoring old format after each CheckResults function call to print
     // correct format in current loop
     std::cout.copyfmt(old_state);
@@ -505,7 +580,9 @@ int ShimMetrics::HostSpeed(sycl::queue &q) {
 
   std::cout << "\nHost write top speed = " << std::setprecision(2) << std::fixed
             << write_topspeed << " MB/s\n";
-  std::cout << "Host read top speed = " << read_topspeed << " MB/s\n\n";
+  std::cout << "Host read top speed = " << read_topspeed << " MB/s\n";
+  std::cout << "Host read-write top speed = " << readwrite_topspeed
+            << " MB/s\n\n";
   std::cout << "\nHOST-TO-MEMORY BANDWIDTH = " << std::setprecision(0)
             << ((read_topspeed + write_topspeed) / 2) << " MB/s\n\n";
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/board_test.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/board_test.hpp
@@ -552,20 +552,22 @@ int ShimMetrics::HostSpeed(sycl::queue &q) {
   std::cout << "\nReading and writing " << (kMaxBytes / kKB)
             << " KBs with block size (in bytes) below:\n\n";
   std::cout << std::setw(10) << std::right << "Block Size "
-            // << std::setw(10) << std::right << "Avg"
-            // << std::setw(10) << std::right << "Max"
-            // << std::setw(10) << std::right << "Min"
+            << std::setw(10) << std::right << "Avg"
+            << std::setw(10) << std::right << "Max"
+            << std::setw(10) << std::right << "Min"
             << std::setw(10) << std::right << "End-End"
             << std::setw(10) << std::right << "(MB/s)\n";
 
   for (size_t i = 0; i < iterations; i++, block_bytes *= 2) {
     std::cout << std::setw(10) << block_bytes << " "
               << std::fixed << std::setprecision(2)
-              // << std::setw(10) << "n/a"
-              // << std::setw(10) << "n/a"
-              // << std::setw(10) << "n/a"
+              << std::setw(10) << rw_bw[i].average
+              << std::setw(10) << rw_bw[i].fastest
+              << std::setw(10) << rw_bw[i].slowest
               << std::setw(10) << rw_bw[i].total << "\n";
-    // if (rw_bw[i].fastest > readwrite_topspeed) readwrite_topspeed = rw_bw[i].fastest;
+    if (rw_bw[i].fastest > readwrite_topspeed) {
+      readwrite_topspeed = rw_bw[i].fastest;
+    }
     if (rw_bw[i].total > readwrite_topspeed) {
       readwrite_topspeed = rw_bw[i].total;
     }

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/board_test.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/board_test.hpp
@@ -549,7 +549,7 @@ int ShimMetrics::HostSpeed(sycl::queue &q) {
   // Fastest transfer value used in read-write bandwidth calculation
   float readwrite_topspeed = 0;
 
-  std::cout << "\nReading-writing " << (kMaxBytes / kKB)
+  std::cout << "\nReading and writing " << (kMaxBytes / kKB)
             << " KBs with block size (in bytes) below:\n\n";
   std::cout << std::setw(10) << std::right << "Block Size "
             // << std::setw(10) << std::right << "Avg"

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/board_test.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/board_test.hpp
@@ -357,9 +357,9 @@ size_t ShimMetrics::TestGlobalMem(sycl::queue &q) {
 // More details about these funtions can be found with the corresponsing
 // definitions
 // 1. size_t TestGlobalMem(queue &q)
-// 2. struct Speed WriteSpeed(queue &q, buffer<char,1> &device_buffer1, char
+// 2. struct Speed WriteSpeed(queue &q, buffer<char,1> &device_buffer, char
 // *hostbuf_wr, size_t block_bytes, size_t total_bytes)
-// 3. struct Speed ReadSpeed(queue &q, buffer<char,1> &device_buffer1, char
+// 3. struct Speed ReadSpeed(queue &q, buffer<char,1> &device_buffer, char
 // *hostbuf_rd, size_t block_bytes, size_t total_bytes)
 // 4. struct Speed ReadWriteSpeed(queue &q, buffer<char, 1> &device_buffer1, 
 // buffer<char, 1> &device_buffer2, char *hostbuf_1, char *hostbuf_2, 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/helper.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/helper.hpp
@@ -118,6 +118,50 @@ unsigned long SyclGetQStExecTimeNs(sycl::event e) {
   return (end_time - start_time);
 }  // End of SyclGetQStExecTimeNs
 
+///////////////////////////////////////////////////
+// **** SyclWhichEventStartedFirst function **** //
+///////////////////////////////////////////////////
+
+// Input:
+// event e1 - Sycl event with profiling information
+// event e2 - another Sycl event with profiling information
+// Returns:
+// Which event started first based on time at command submission
+
+// The function does the following task:
+// Gets profiling information from two different Sycl events and
+// returns the event with the earlier start time
+
+sycl::event SyclWhichEventStartedFirst(sycl::event e1, sycl::event e2) {
+  unsigned long start_time1 =
+      e1.get_profiling_info<sycl::info::event_profiling::command_start>();
+  unsigned long start_time2 =
+      e2.get_profiling_info<sycl::info::event_profiling::command_start>();
+  return (start_time1 < start_time2) ? e1 : e2;
+}
+
+///////////////////////////////////////////////////
+// **** SyclWhichEventEndedLast function **** //
+///////////////////////////////////////////////////
+
+// Input:
+// event e1 - Sycl event with profiling information
+// event e2 - another Sycl event with profiling information
+// Returns:
+// Which event ended last based on time at command end
+
+// The function does the following task:
+// Gets profiling information from two different Sycl events and
+// returns the event with the later end time
+
+sycl::event SyclWhichEventEndedLast(sycl::event e1, sycl::event e2) {
+  unsigned long end_time1 =
+      e1.get_profiling_info<sycl::info::event_profiling::command_end>();
+  unsigned long end_time2 =
+      e2.get_profiling_info<sycl::info::event_profiling::command_end>();
+  return (end_time1 > end_time2) ? e1 : e2;
+}
+
 ///////////////////////////////////////////
 // **** SyclGetTotalTimeNs function **** //
 ///////////////////////////////////////////

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/host_speed.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/host_speed.hpp
@@ -196,7 +196,7 @@ struct Speed ReadSpeed(sycl::queue &q, sycl::buffer<char, 1> &device_buffer,
 // 2. Calculate bandwidth based on measured time for each transfer
 
 struct Speed ReadWriteSpeed(sycl::queue &q,
-                            sycl::buffer<char, 1> &device_buffer1, 
+                            sycl::buffer<char, 1> &device_buffer1,
                             sycl::buffer<char, 1> &device_buffer2,
                             char *hostbuf_1, char *hostbuf_2,
                             size_t block_bytes, size_t total_bytes) {
@@ -238,7 +238,6 @@ struct Speed ReadWriteSpeed(sycl::queue &q,
           device_buffer2, h, buf_range, buf_offset);
       h.copy(mem, &hostbuf_2[buf_offset]);
     });
-
   }
   // Wait for copy to complete
   q.wait();
@@ -246,7 +245,9 @@ struct Speed ReadWriteSpeed(sycl::queue &q,
   // **** Get the time for each transfer from Sycl event array **** //
 
   auto end = std::chrono::steady_clock::now();
-  double time_span = std::chrono::duration_cast<std::chrono::duration<double>>(end - start).count();
+  float time_span =
+      std::chrono::duration_cast<std::chrono::duration<double>>(end - start)
+          .count();
 
   struct Speed speed_wr;
   speed_wr.average = 0.0f;
@@ -254,8 +255,10 @@ struct Speed ReadWriteSpeed(sycl::queue &q,
   speed_wr.slowest = 1.0e7f;
 
   // for (size_t i = 0; i < num_xfers; i++) {
-  //   float time_s = std::chrono::duration_cast<std::chrono::duration<double>>(end - start).count();
-  //   float speed_MBps = ((float)block_bytes / kMB) / ((float)time_ns * 1e-9);
+  //   float time_s =
+  //   std::chrono::duration_cast<std::chrono::duration<double>>(end -
+  //   start).count(); float speed_MBps = ((float)block_bytes / kMB) /
+  //   ((float)time_ns * 1e-9);
 
   //   if (speed_MBps > speed_wr.fastest) speed_wr.fastest = speed_MBps;
   //   if (speed_MBps < speed_wr.slowest) speed_wr.slowest = speed_MBps;
@@ -266,11 +269,11 @@ struct Speed ReadWriteSpeed(sycl::queue &q,
   // Average write bandwidth
   // speed_wr.average =
   //     ((float)total_bytes / kMB) / ((float)speed_wr.average * 1e-9);
-  speed_wr.total = ((float)total_bytes / kMB) / ((float)time_span);
+  speed_wr.total = ((float)total_bytes / kMB) / time_span;
 
   return speed_wr;
 
-}  // End of ReadWriteSpeed
+} // End of ReadWriteSpeed
 
 
 /////////////////////////////////////


### PR DESCRIPTION
# Existing Sample Changes
## Description

Adding a bi-directional host read-write test to the board_test sample.

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used